### PR TITLE
Fix URL for Icon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export const App: React.FunctionComponent = () => {
       gap={15}
     >
       <img
-        src="https://raw.githubusercontent.com/Microsoft/just/master/packages/just-stack-uifabric/template/src/components/fabric.png"
+        src="https://raw.githubusercontent.com/Microsoft/just/master/packages/just-stack-uifabric/plop-templates/src/fabric.png"
         alt="logo"
       />
       <Text variant="xxLarge" styles={boldStyle}>


### PR DESCRIPTION
Looks to have been broken from [this](https://github.com/microsoft/just/commit/3f32788be41da61f9df1fc52c50bba58fcf72477#diff-32196370bb7314242ccb56bf6373978d) change.