### PR TITLE
Modified @types/jest version to at least 26 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@types/jest": "24.0.12",
+    "@types/jest": "^26.0.1",
     "@types/node": "11.13.8",
     "@types/react": "16.8.15",
     "@types/react-dom": "16.8.4",


### PR DESCRIPTION
The commit is a fix to opened issues #10,#14.#16.
The package.json is modified to use a jest version of at least 26.