### PR TITLE
Bump typescript from 3.4.5 to 3.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.0",
-    "typescript": "3.4.5"
+    "typescript": "3.9.7"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
The older version of typescript is causing issue with jest-diff which uses import type. "import type" requires minimum version of typescript 3.8. 